### PR TITLE
Add list of publications by current lab members

### DIFF
--- a/publications.qmd
+++ b/publications.qmd
@@ -3,28 +3,25 @@ title: "Publications"
 ---
 
 ```{r orchid-works, echo = FALSE, output = FALSE, warning = FALSE}
-orchid <- c(   
-  # Adriana
-  "0000-0002-5345-4917",
-  # Andy
-  "0000-0002-8609-6204",
+
+lab_member_details <- rbind(
+  c("Andy Purvis", "0000-0002-8609-6204"),
+  c("Adriana De Palma", "0000-0002-5345-4917"),
+  c("Victoria J. Burton", "0000-0003-0122-3292"),
+  c("Alexa Varah", "0000-0002-5024-0737"),
+  c("Sophie Jane Tudge", "0000-0002-0447-9448"),
+  c("Justin E. Isip", "0000-0002-9686-8888")
   # Sara?
   # Connor?
-  # Victoria
-  "0000-0003-0122-3292",
-  # Alexa
-  "0000-0002-5024-0737",
   # Patrick?
-  # Sophie
-  "0000-0002-0447-9448",
-  # Justin
-  "0000-0002-9686-8888"
-)
+) |>
+  as.data.frame() |>
+  setNames(c("name", "orcid"))
 
 # get all works from orcID using open alex
 works_from_orcids <- openalexR::oa_fetch(
   entity = "works",
-  author.orcid = orchid,
+  author.orcid = lab_member_details$orcid,
   verbose = TRUE,
   output = "dataframe",
   abstract = FALSE
@@ -43,7 +40,7 @@ distinct_works <- works_from_orcids  |>
 ```{r formatted-references, echo = FALSE, cache = TRUE}
 
 # furnction to format OpenAlex outputs into a Harvard-style reference
-GetFormattedReference <- function(reference) {
+GetFormattedReference <- function(reference, lab_member_details) {
   
   # extract the authors
   authors <- reference$authorships
@@ -52,6 +49,10 @@ GetFormattedReference <- function(reference) {
   })
   # transform into a vector
   authors <- unlist(authors)
+  
+  # embolden lab author
+  authors[authors %in% lab_member_details$name] <- gluedown::md_bold(authors[authors %in% lab_member_details$name])
+  
   # make a full author list for the reference
   if(length(authors) == 1) {
     author_list <- authors
@@ -88,7 +89,8 @@ distinct_references <- rep(NA, nrow(distinct_works))
 # get the formatted reference for each open Alex entry
 for(i in 1:length(distinct_references)) {
   distinct_references[i] <- GetFormattedReference(
-    distinct_works[i, ]
+    distinct_works[i, ],
+    lab_member_details = lab_member_details
   )
 }
 

--- a/publications.qmd
+++ b/publications.qmd
@@ -10,7 +10,8 @@ lab_member_details <- rbind(
   c("Victoria J. Burton", "0000-0003-0122-3292"),
   c("Alexa Varah", "0000-0002-5024-0737"),
   c("Sophie Jane Tudge", "0000-0002-0447-9448"),
-  c("Justin E. Isip", "0000-0002-9686-8888")
+  c("Justin E. Isip", "0000-0002-9686-8888"),
+  c("Patrick A. Walkden", "0000-0002-5922-8777")
   # Sara?
   # Connor?
   # Patrick?
@@ -36,6 +37,42 @@ distinct_works <- works_from_orcids  |>
   # sort with the most recent publications first
   dplyr::arrange(dplyr::desc(publication_year))
 ```
+```{r add-topic, echo = FALSE, cache = TRUE}
+
+# get a vector of topics for each reference
+all_topics <- lapply(distinct_works$topics, function(x) {
+  
+  if("display_name" %in% names(x)){
+    x[x$type == "field", "display_name"] |>
+      dplyr::pull(display_name) |>
+      stringr::str_replace_all(" ", "_") |>
+      unique()
+  } else {
+    "no_topic"
+  }
+
+})
+
+# find out which references have no topic
+no_topics <- which(all_topics == "no_topic")
+# only a few of these look relevant (Adapting to a diverse world, Living Planet Report 2018: Aiming Higher and Chapter 2.2 Status and Trends –Nature)
+
+# topics to remove
+to_remove <- c(
+  which(all_topics %in% c(  
+    # incorrect datasets
+    "Health_Professions", "Medicine", "Engineering",
+    # datasets that we'll list in the outputs section
+    "Computer_Science")
+  ), 
+  grep("schistosomes in baboons", distinct_works$title)
+)
+
+distinct_works <- distinct_works[-to_remove, ]
+
+```
+
+
 
 ```{r formatted-references, echo = FALSE, cache = TRUE}
 
@@ -43,8 +80,7 @@ distinct_works <- works_from_orcids  |>
 GetFormattedReference <- function(reference, lab_member_details) {
   
   # extract the authors
-  authors <- reference$authorships
-  authors <- lapply(authors, function(x) {
+  authors <- lapply(reference$authorships, function(x) {
     x$display_name
   })
   # transform into a vector
@@ -98,7 +134,7 @@ GetFormattedReference <- function(reference, lab_member_details) {
   
   # format the year
   year <- paste0(" (", reference$publication_year, "). ")
-
+  
   # add the relevant information together
   formatted_ref <- paste0(
     author_list,

--- a/publications.qmd
+++ b/publications.qmd
@@ -83,7 +83,7 @@ GetFormattedReference <- function(reference, lab_member_details) {
   formatted_ref <- paste0(
     author_list,
     " (", reference$publication_year, "). ",
-    reference$title, ", ",
+    title, ", ",
     gluedown::md_italic(reference$source_display_name), ", ",
     link
   )
@@ -104,6 +104,9 @@ for(i in 1:length(distinct_references)) {
 }
 
 ```
+
+The following is a list of publications from members of the lab. 
+
 
 
 ```{r render-references, output = "asis", echo = FALSE}

--- a/publications.qmd
+++ b/publications.qmd
@@ -125,7 +125,15 @@ for(i in 1:length(distinct_references)) {
 
 ```
 
-The following is a list of publications from members of the lab. These references are automatically fetched using the `{openalexR}` package.
+
+```{r round-down, echo = FALSE}
+RoundDown100 <- function(x) {
+  return(floor(x / 100) * 100)
+}
+```
+
+
+The following is a list of publications from members of the lab. These references are automatically fetched using the `{openalexR}` package. Our current lab members combined have written over `r nrow(distinct_works) |> RoundDown100()` publications, cited over `r sum(distinct_works$cited_by_count) |> RoundDown100() |> scales::number(big.mark = ",")` times.
 
 ```{r render-references, output = "asis", echo = FALSE}
 gluedown::md_paragraph(distinct_references)

--- a/publications.qmd
+++ b/publications.qmd
@@ -64,10 +64,19 @@ GetFormattedReference <- function(reference, lab_member_details) {
   }
   
   # extract the doi or url
-  link <- ifelse(
-    is.na(reference$doi),
-    reference$source_id,
-    reference$doi
+  if(!is.na(reference$doi)) {
+    link <- gluedown::md_link(reference$doi, reference$doi)
+  } else if (!is.na(reference$source_id)) {
+    link <- gluedown::md_link(reference$source_id, reference$source_id)
+  } else {
+    link <- gluedown::md_link(reference$landing_page_url, reference$landing_page_url)
+  }
+  
+  # transform the title to sentence case if needed
+  title <- ifelse(
+    reference$title == toupper(reference$title),
+    stringr::str_to_sentence(reference$title),
+    reference$title
   )
 
   # add the relevant information together
@@ -76,7 +85,7 @@ GetFormattedReference <- function(reference, lab_member_details) {
     " (", reference$publication_year, "). ",
     reference$title, ", ",
     gluedown::md_italic(reference$source_display_name), ", ",
-    gluedown::md_link(link, link)
+    link
   )
   
   # return the formatted reference

--- a/publications.qmd
+++ b/publications.qmd
@@ -30,13 +30,17 @@ works_from_orcids <- openalexR::oa_fetch(
   abstract = FALSE
 )
 
-# get only the unique references
-distinct_works <- works_from_orcids |>
+distinct_works <- works_from_orcids  |>
+  # we don't actually have any retracted works in this list
+  # but let's remove them just in case
+  dplyr::filter(is_retracted == FALSE) |>
+  # keep only the unique references
   dplyr::distinct(tolower(display_name), .keep_all = TRUE) |>
+  # sort with the most recent publications first
   dplyr::arrange(dplyr::desc(publication_year))
 ```
 
-```{r formatted-references, echo = FALSE}
+```{r formatted-references, echo = FALSE, cache = TRUE}
 
 # furnction to format OpenAlex outputs into a Harvard-style reference
 GetFormattedReference <- function(reference) {
@@ -58,13 +62,20 @@ GetFormattedReference <- function(reference) {
       paste(" & ", authors[length(authors)])
   }
   
+  # extract the doi or url
+  link <- ifelse(
+    is.na(reference$doi),
+    reference$source_id,
+    reference$doi
+  )
+
   # add the relevant information together
   formatted_ref <- paste0(
     author_list,
     " (", reference$publication_year, "). ",
     reference$title, ", ",
     gluedown::md_italic(reference$source_display_name), ", ",
-    gluedown::md_link(reference$doi, reference$doi)
+    gluedown::md_link(link, link)
   )
   
   # return the formatted reference
@@ -84,7 +95,7 @@ for(i in 1:length(distinct_references)) {
 ```
 
 
-```{r render-references, output = "asis"}
-gluedown::md_indent(distinct_references)
+```{r render-references, output = "asis", echo = FALSE}
+gluedown::md_paragraph(distinct_references)
 ```
 

--- a/publications.qmd
+++ b/publications.qmd
@@ -65,11 +65,11 @@ GetFormattedReference <- function(reference, lab_member_details) {
   
   # extract the doi or url
   if(!is.na(reference$doi)) {
-    link <- gluedown::md_link(reference$doi, reference$doi)
+    link <- gluedown::md_autolink(reference$doi)
   } else if (!is.na(reference$source_id)) {
-    link <- gluedown::md_link(reference$source_id, reference$source_id)
+    link <- gluedown::md_autolink(reference$source_id)
   } else {
-    link <- gluedown::md_link(reference$landing_page_url, reference$landing_page_url)
+    link <- gluedown::md_autolink(reference$landing_page_url)
   }
   
   # transform the title to sentence case if needed
@@ -77,14 +77,34 @@ GetFormattedReference <- function(reference, lab_member_details) {
     reference$title == toupper(reference$title),
     stringr::str_to_sentence(reference$title),
     reference$title
-  )
+  ) |>
+    paste0(", ")
+  
+  # get the journal title if there is one
+  if(is.na(reference$source_display_name)) {
+    source <- ""
+  } else {
+    # transform to sentence case if needed
+    if(reference$source_display_name == toupper(reference$source_display_name)) {
+      source <- stringr::str_to_sentence(reference$source_display_name) |>
+        gluedown::md_italic() |>
+        paste0(", ")
+    } else {
+      source <- reference$source_display_name |>
+        gluedown::md_italic() |>
+        paste0(", ")
+    }
+  }
+  
+  # format the year
+  year <- paste0(" (", reference$publication_year, "). ")
 
   # add the relevant information together
   formatted_ref <- paste0(
     author_list,
-    " (", reference$publication_year, "). ",
-    title, ", ",
-    gluedown::md_italic(reference$source_display_name), ", ",
+    year,
+    title,
+    source,
     link
   )
   
@@ -105,9 +125,7 @@ for(i in 1:length(distinct_references)) {
 
 ```
 
-The following is a list of publications from members of the lab. 
-
-
+The following is a list of publications from members of the lab. These references are automatically fetched using the `{openalexR}` package.
 
 ```{r render-references, output = "asis", echo = FALSE}
 gluedown::md_paragraph(distinct_references)

--- a/publications.qmd
+++ b/publications.qmd
@@ -1,3 +1,90 @@
 ---
 title: "Publications"
 ---
+
+```{r orchid-works, echo = FALSE, output = FALSE, warning = FALSE}
+orchid <- c(   
+  # Adriana
+  "0000-0002-5345-4917",
+  # Andy
+  "0000-0002-8609-6204",
+  # Sara?
+  # Connor?
+  # Victoria
+  "0000-0003-0122-3292",
+  # Alexa
+  "0000-0002-5024-0737",
+  # Patrick?
+  # Sophie
+  "0000-0002-0447-9448",
+  # Justin
+  "0000-0002-9686-8888"
+)
+
+# get all works from orcID using open alex
+works_from_orcids <- openalexR::oa_fetch(
+  entity = "works",
+  author.orcid = orchid,
+  verbose = TRUE,
+  output = "dataframe",
+  abstract = FALSE
+)
+
+# get only the unique references
+distinct_works <- works_from_orcids |>
+  dplyr::distinct(tolower(display_name), .keep_all = TRUE) |>
+  dplyr::arrange(dplyr::desc(publication_year))
+```
+
+```{r formatted-references, echo = FALSE}
+
+# furnction to format OpenAlex outputs into a Harvard-style reference
+GetFormattedReference <- function(reference) {
+  
+  # extract the authors
+  authors <- reference$authorships
+  authors <- lapply(authors, function(x) {
+    x$display_name
+  })
+  # transform into a vector
+  authors <- unlist(authors)
+  # make a full author list for the reference
+  if(length(authors) == 1) {
+    author_list <- authors
+  } else if (length(authors) == 2) {
+    author_list <- paste0(authors, collapse = " & ")
+  } else {
+    author_list <- paste0(authors[1:length(authors) - 1], collapse = ", ") |>
+      paste(" & ", authors[length(authors)])
+  }
+  
+  # add the relevant information together
+  formatted_ref <- paste0(
+    author_list,
+    " (", reference$publication_year, "). ",
+    reference$title, ", ",
+    gluedown::md_italic(reference$source_display_name), ", ",
+    gluedown::md_link(reference$doi, reference$doi)
+  )
+  
+  # return the formatted reference
+  return(formatted_ref)
+}
+
+# set up an empty vector to hold the results
+distinct_references <- rep(NA, nrow(distinct_works))
+
+# get the formatted reference for each open Alex entry
+for(i in 1:length(distinct_references)) {
+  distinct_references[i] <- GetFormattedReference(
+    distinct_works[i, ]
+  )
+}
+
+```
+
+
+```{r render-references, output = "asis"}
+gluedown::md_indent(distinct_references)
+```
+


### PR DESCRIPTION
Use {openalexr} package to extract publications by lab members using orchid numbers and use {gluedown} to format prettily. There is a little bit of manual work here to remove publications that are clearly not written by our lab.

There are still some known issues (e.g. #15, #16, #17) but these can be fixed in a later pull request.